### PR TITLE
Removed stable running timeout.  Ignore CVS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-
+CVS/
+.cvsignore
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/rfwscopedaq/main.py
+++ b/src/rfwscopedaq/main.py
@@ -86,8 +86,7 @@ def process_cavities(cavities, out_dir, output: str):
     for cavity in cavities:
         threads.append(DaqThread(exit_event=EXIT_EVENT, epics_name=cavity, duration=cfg.get_parameter('duration'),
                                  out_dir=out_dir, signals=cfg.get_parameter('signals'),
-                                 timeout=cfg.get_parameter('timeout'), db_pool=pool, output=output,
-                                 meta_pvs=cfg.get_parameter('meta_pvs')))
+                                 db_pool=pool, output=output, meta_pvs=cfg.get_parameter('meta_pvs')))
 
     # Kick off the threads
     for thread in threads:

--- a/test/unit/test_rfwscopedaq/test_collect_data.py
+++ b/test/unit/test_rfwscopedaq/test_collect_data.py
@@ -59,7 +59,7 @@ class TestDAQThread(TestCase):
             with patch("rfwscopedaq.collect_data.Cavity",
                        new=lambda *args, **kwargs: MockCavity(0.2, *args, **kwargs)):
                 thread = DaqThread(exit_event=Event(), epics_name=epics_name, out_dir=dir_path,
-                                   signals=["GMES", "PMES"], duration=5.0, timeout=1.0, db_pool=None, output="file",
+                                   signals=["GMES", "PMES"], duration=5.0, db_pool=None, output="file",
                                    meta_pvs=[])
 
                 thread.write_files(results=result_dict, start_time=start_time, end_time=end_time, f_metadata=f_metadata,


### PR DESCRIPTION
We don't need to timeout on waiting for stable running.  Instead just check for data collection stop time.  Also ignore any CVS related files used by CSUE